### PR TITLE
Fix NaN results

### DIFF
--- a/WorldWideAstronomy/WWA/Astronomy/Astrometry/atic13.cs
+++ b/WorldWideAstronomy/WWA/Astronomy/Astrometry/atic13.cs
@@ -41,6 +41,9 @@ namespace WorldWideAstronomy
         {
             /* Star-independent astrometry parameters */
             wwaASTROM astrom = new wwaASTROM();
+            astrom.eb = new double[3];
+            astrom.eh = new double[3];
+            astrom.bpn = new double[3, 3];
 
             /* Star-independent astrometry parameters. */
             wwaApci13(date1, date2, ref astrom, ref eo);

--- a/WorldWideAstronomy/WWA/Astronomy/Astrometry/atoc13.cs
+++ b/WorldWideAstronomy/WWA/Astronomy/Astrometry/atoc13.cs
@@ -55,6 +55,10 @@ namespace WorldWideAstronomy
         {
             int j;
             wwaASTROM astrom = new wwaASTROM();
+            astrom.eb = new double[3];
+            astrom.eh = new double[3];
+            astrom.bpn = new double[3, 3];
+
             double eo = 0, ri = 0, di = 0;
 
             /* Star-independent astrometry parameters. */

--- a/WorldWideAstronomy/WWATest/Program.cs
+++ b/WorldWideAstronomy/WWATest/Program.cs
@@ -70,7 +70,7 @@ namespace WWA_Test
 
             a = val - valok;
             //if (Math.Abs(a) > dval)
-            if (a != 0.0 && Math.Abs(a) > Math.Abs(dval))
+            if (double.IsNaN(a) || (a != 0.0 && Math.Abs(a) > Math.Abs(dval)))
             {
                 f = Math.Abs(valok / a);
                 status = 1;
@@ -1592,7 +1592,9 @@ namespace WWA_Test
         {
             double date1, date2, eo = 0, ri, di, rc = 0, dc = 0;
             WWA.wwaASTROM astrom = new WWA.wwaASTROM();
-
+            astrom.eb = new double[3];
+            astrom.eh = new double[3];
+            astrom.bpn = new double[3, 3];
 
             date1 = 2456165.5;
             date2 = 0.401182685;
@@ -1628,6 +1630,9 @@ namespace WWA_Test
             double date1, date2, eo = 0, ri, di, rc = 0, dc = 0;
             WWA.wwaLDBODY[] b = new WWA.wwaLDBODY[3];
             WWA.wwaASTROM astrom = new WWA.wwaASTROM();
+            astrom.eb = new double[3];
+            astrom.eh = new double[3];
+            astrom.bpn = new double[3, 3];
 
             date1 = 2456165.5;
             date2 = 0.401182685;


### PR DESCRIPTION
I was getting NaN results from some calls in WWA. I updated the vvd method in WWATest to look for NaN, and re-running reported the following failed tests:

wwaAtic13 failed: rc want 2.7101265045317167 got NaN (1/NaN)
wwaAtic13 failed: dc want 0.17406325376270346 got NaN (1/NaN)
wwaAticq failed: rc want 2.7101265045317167 got NaN (1/NaN)
wwaAticq failed: dc want 0.17406325376270346 got NaN (1/NaN)
wwaAtciqn failed: rc want 2.7099995750330272 got NaN (1/NaN)
wwaAtciqn failed: dc want 0.17399996563164699 got NaN (1/NaN)
wwaAtoc13 failed: R/rc want 2.7099567446607318 got NaN (1/NaN)
wwaAtoc13 failed: R/dc want 0.17416965008964389 got NaN (1/NaN)
wwaAtoc13 failed: H/rc want 2.7099567446607318 got NaN (1/NaN)
wwaAtoc13 failed: H/dc want 0.17416965008964389 got NaN (1/NaN)
wwaAtoc13 failed: A/rc want 2.7099567446607318 got NaN (1/NaN)
wwaAtoc13 failed: A/dc want 0.17416965008964389 got NaN (1/NaN)

These were due to uninitialized arrays in wwaASTROM. In most places throughout the code, a new wwaASTROM instance is followed by these lines:

astrom.eb = new double[3];
astrom.eh = new double[3];
astrom.bpn = new double[3, 3];

I added these to a few places where they were missing, and now all tests pass.
