### PR TITLE
Retarget .NET code to .NET Standard 2.0, which allows use in .NET FX

### DIFF
--- a/WorldWideAstronomy/WWA.Core/WWA.Core.csproj
+++ b/WorldWideAstronomy/WWA.Core/WWA.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Attila Abrudán</Authors>
     <Description>World Wide Astronomy - SOFA</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Really useful library, and it builds and runs fine in .NET Framework as well as .NET Core.  By changing the target framework to .NET Standard 2.0, the resulting DLL (and nuget package) can be used in both .NET Core and .NET Framework. Win/win :)